### PR TITLE
Fix alerts and improve workflow page

### DIFF
--- a/app/components/static-alert.tsx
+++ b/app/components/static-alert.tsx
@@ -1,0 +1,61 @@
+import clsx from "clsx";
+import type React from "react";
+import { Text } from "./text";
+
+const variants = {
+  error: "bg-red-50 border-red-200 text-red-800 dark:bg-red-900/20 dark:border-red-800 dark:text-red-200",
+  warning: "bg-amber-50 border-amber-200 text-amber-800 dark:bg-amber-900/20 dark:border-amber-800 dark:text-amber-200",
+  info: "bg-blue-50 border-blue-200 text-blue-800 dark:bg-blue-900/20 dark:border-blue-800 dark:text-blue-200",
+  success: "bg-green-50 border-green-200 text-green-800 dark:bg-green-900/20 dark:border-green-800 dark:text-green-200",
+};
+
+export function StaticAlert({
+  variant = "info",
+  className,
+  children,
+  ...props
+}: {
+  variant?: keyof typeof variants;
+  className?: string;
+  children: React.ReactNode;
+} & React.ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      {...props}
+      className={clsx(
+        className,
+        "rounded-lg border p-4",
+        variants[variant]
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function StaticAlertTitle({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<"h3">) {
+  return (
+    <h3
+      {...props}
+      className={clsx(
+        className,
+        "text-base/6 font-semibold"
+      )}
+    />
+  );
+}
+
+export function StaticAlertDescription({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof Text>) {
+  return (
+    <Text
+      {...props}
+      className={clsx(className, "mt-2")}
+    />
+  );
+}

--- a/workflow.jsonc
+++ b/workflow.jsonc
@@ -8,19 +8,19 @@
   "connections": {
     "googleAdmin": {
       "base": "https://admin.googleapis.com/admin/directory/v1",
-      "auth": "Bearer {googleAccessToken}",
+      "auth": "Bearer {googleAccessToken}"
     },
     "googleCI": {
       "base": "https://cloudidentity.googleapis.com/v1",
-      "auth": "Bearer {googleAccessToken}",
+      "auth": "Bearer {googleAccessToken}"
     },
     "graphGA": {
       "base": "https://graph.microsoft.com/v1.0",
-      "auth": "Bearer {azureAccessToken}",
+      "auth": "Bearer {azureAccessToken}"
     },
     "graphBeta": {
       "base": "https://graph.microsoft.com/beta",
-      "auth": "Bearer {azureAccessToken}",
+      "auth": "Bearer {azureAccessToken}"
     },
   },
 


### PR DESCRIPTION
## Summary
- add `static-alert` component for static alert display
- use the new component on the main page
- optimize callbacks with `useCallback`
- better loading spinner and routing
- improve error handling and workflow.jsonc formatting

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845dd904cf88322a491bd4b0f993104