### PR TITLE
Improve manual step UI

### DIFF
--- a/app/components/workflow/manual-step-dialog.tsx
+++ b/app/components/workflow/manual-step-dialog.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import { ManualStepGuide } from "./manual-step-guide";
+import { Step } from "@/app/lib/workflow";
+
+interface ManualStepDialogProps {
+  step: Step;
+  variables: Record<string, string>;
+  isOpen: boolean;
+  onComplete: () => void;
+}
+
+export function ManualStepDialog({
+  step,
+  variables,
+  isOpen,
+  onComplete,
+}: ManualStepDialogProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={() => {}}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{step.name}</DialogTitle>
+          <DialogDescription>
+            Complete the following steps in your Azure Portal
+          </DialogDescription>
+        </DialogHeader>
+
+        <ManualStepGuide step={step} variables={variables} onComplete={onComplete} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/app/components/workflow/manual-step-guide.tsx
+++ b/app/components/workflow/manual-step-guide.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useState } from "react";
+import { Alert, AlertDescription } from "../ui/alert";
+import { Button } from "../ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "../ui/card";
+import { Checkbox } from "../ui/checkbox";
+import { ExternalLink, Info, CheckCircle2, Copy } from "lucide-react";
+import { Step } from "@/app/lib/workflow";
+import { cn } from "@/app/lib/utils";
+
+interface ManualStepGuideProps {
+  step: Step;
+  variables: Record<string, string>;
+  onComplete: () => void;
+}
+
+interface StepInstruction {
+  text: string;
+  code?: string;
+  link?: { url: string; text: string };
+  important?: boolean;
+}
+
+export function ManualStepGuide({
+  step,
+  variables,
+  onComplete,
+}: ManualStepGuideProps) {
+  const [checkedSteps, setCheckedSteps] = useState<Set<number>>(new Set());
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const copyToClipboard = async (text: string, id: string) => {
+    await navigator.clipboard.writeText(text);
+    setCopied(id);
+    setTimeout(() => setCopied(null), 2000);
+  };
+
+  const getInstructions = (): StepInstruction[] => {
+    switch (step.name) {
+      case "Assign Users to SSO App":
+        return [
+          {
+            text: "Open Azure Portal and navigate to your SSO Enterprise Application",
+            link: {
+              url:
+                "https://portal.azure.com/#blade/Microsoft_AAD_IAM/StartboardApplicationsMenuBlade/AllApps",
+              text: "Open Azure Portal",
+            },
+          },
+          {
+            text: "Click on 'Users and groups' in the left menu",
+          },
+          {
+            text: "Click 'Add user/group' button",
+            important: true,
+          },
+          {
+            text: "Choose one of these options:",
+            important: true,
+          },
+          {
+            text: "Option A: Add specific users or groups who need Google Workspace access",
+          },
+          {
+            text: "Option B: Add 'All Users' group for organization-wide access (recommended for most setups)",
+          },
+          {
+            text: "If adding a group, copy this Object ID for later use:",
+            code: variables.principalId || "Will be set after selection",
+          },
+          {
+            text: "Click 'Select' and then 'Assign' to save your changes",
+          },
+        ];
+
+      case "Test SSO Configuration":
+        return [
+          {
+            text: "Open an incognito/private browser window",
+          },
+          {
+            text: "Navigate to any Google Workspace service:",
+            link: { url: "https://mail.google.com", text: "Try Gmail" },
+          },
+          {
+            text: "Enter an email address from your domain:",
+            code: `user@${variables.primaryDomain || "yourdomain.com"}`,
+          },
+          {
+            text: "You should be redirected to Microsoft login",
+          },
+          {
+            text: "Sign in with your Microsoft credentials",
+          },
+          {
+            text: "Verify you're successfully logged into Google Workspace",
+            important: true,
+          },
+          {
+            text: "If login fails, check the SAML response in browser dev tools (Network tab)",
+          },
+        ];
+
+      default:
+        return [
+          {
+            text: step.description || "Complete this step manually",
+            important: true,
+          },
+        ];
+    }
+  };
+
+  const instructions = getInstructions();
+  const allStepsChecked = checkedSteps.size === instructions.length;
+
+  const toggleStep = (index: number) => {
+    const newChecked = new Set(checkedSteps);
+    if (newChecked.has(index)) {
+      newChecked.delete(index);
+    } else {
+      newChecked.add(index);
+    }
+    setCheckedSteps(newChecked);
+  };
+
+  return (
+    <Card className="border-blue-200 dark:border-blue-800">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Info className="h-5 w-5 text-blue-600" />
+          Manual Configuration Required
+        </CardTitle>
+        <CardDescription>{step.description}</CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        <Alert>
+          <AlertDescription>
+            Follow these steps in order. Check each box as you complete the step.
+          </AlertDescription>
+        </Alert>
+
+        <div className="space-y-3">
+          {instructions.map((instruction, index) => (
+            <div
+              key={index}
+              className={cn(
+                "flex gap-3 p-3 rounded-lg transition-colors",
+                checkedSteps.has(index)
+                  ? "bg-green-50 dark:bg-green-950/20"
+                  : "bg-gray-50 dark:bg-gray-900",
+              )}
+            >
+              <Checkbox
+                checked={checkedSteps.has(index)}
+                onCheckedChange={() => toggleStep(index)}
+                className="mt-0.5"
+              />
+
+              <div className="flex-1 space-y-2">
+                <p
+                  className={cn(
+                    "text-sm",
+                    instruction.important && "font-medium",
+                    checkedSteps.has(index) && "line-through opacity-60",
+                  )}
+                >
+                  {instruction.text}
+                </p>
+
+                {instruction.code && (
+                  <div className="flex items-center gap-2">
+                    <code className="flex-1 bg-white dark:bg-zinc-800 px-3 py-1.5 rounded border text-xs font-mono">
+                      {instruction.code}
+                    </code>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => copyToClipboard(instruction.code!, `code-${index}`)}
+                    >
+                      {copied === `code-${index}` ? (
+                        <CheckCircle2 className="h-3 w-3" />
+                      ) : (
+                        <Copy className="h-3 w-3" />
+                      )}
+                    </Button>
+                  </div>
+                )}
+
+                {instruction.link && (
+                  <Button
+                    variant="link"
+                    size="sm"
+                    className="h-auto p-0 text-blue-600"
+                    asChild
+                  >
+                    <a
+                      href={instruction.link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {instruction.link.text}
+                      <ExternalLink className="ml-1 h-3 w-3" />
+                    </a>
+                  </Button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {step.name === "Assign Users to SSO App" && (
+          <Alert className="border-amber-200 bg-amber-50 dark:bg-amber-950/20">
+            <AlertDescription>
+              <strong>Tip:</strong> For initial testing, add yourself or a test user. You can add more users or groups later without re-running this workflow.
+            </AlertDescription>
+          </Alert>
+        )}
+      </CardContent>
+
+      <CardFooter>
+        <Button onClick={onComplete} disabled={!allStepsChecked} className="w-full">
+          {allStepsChecked ? (
+            <>
+              <CheckCircle2 className="mr-2 h-4 w-4" />
+              Mark as Complete
+            </>
+          ) : (
+            <>
+              Complete All Steps First
+              <span className="ml-2 text-xs opacity-60">
+                ({checkedSteps.size}/{instructions.length})
+              </span>
+            </>
+          )}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+

--- a/app/components/workflow/step-card.tsx
+++ b/app/components/workflow/step-card.tsx
@@ -4,7 +4,7 @@ import { executeWorkflowStep } from "@/app/actions/workflow-execution";
 import { cn } from "@/app/lib/utils";
 import { LogEntry, Step, StepStatus } from "@/app/lib/workflow";
 import { PasswordDisplay } from "./password-display";
-import { ManualStepModal } from "./manual-step-modal";
+import { ManualStepDialog } from "./manual-step-dialog";
 import {
   AlertTriangle,
   CheckCircle,
@@ -28,6 +28,7 @@ interface StepCardProps {
   status: StepStatus;
   canExecute: boolean;
   isAuthValid: boolean;
+  variables: Record<string, string>;
 }
 
 export function StepCard({
@@ -35,6 +36,7 @@ export function StepCard({
   status,
   canExecute,
   isAuthValid,
+  variables,
 }: StepCardProps) {
   const [isPending, startTransition] = useTransition();
   const [localExecutionResult, setLocalExecutionResult] = useState<{
@@ -42,7 +44,7 @@ export function StepCard({
     error?: string;
     logs?: LogEntry[];
   }>({ status: null });
-  const [showManualModal, setShowManualModal] = useState(false);
+  const [showManualDialog, setShowManualDialog] = useState(false);
 
   // Use local execution result if available, otherwise use prop status
   const effectiveStatus = localExecutionResult.status
@@ -145,15 +147,16 @@ export function StepCard({
               <div className="flex items-center gap-2">
                 {step.manual && effectiveStatus.status === "pending" && (
                   <>
-                    <Button onClick={() => setShowManualModal(true)}>
-                      Configure Manually
+                    <Button onClick={() => setShowManualDialog(true)} variant="default">
+                      Start Manual Setup
                     </Button>
-                    <ManualStepModal
+                    <ManualStepDialog
                       step={step}
-                      isOpen={showManualModal}
+                      variables={variables}
+                      isOpen={showManualDialog}
                       onComplete={() => {
-                        setShowManualModal(false);
-                        window.location.reload();
+                        setShowManualDialog(false);
+                        handleExecute(step.name);
                       }}
                     />
                   </>

--- a/app/components/workflow/variable-input-dialog.tsx
+++ b/app/components/workflow/variable-input-dialog.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import { Alert, AlertDescription } from "../ui/alert";
+import { setWorkflowVariable } from "@/app/actions/workflow-state";
+import { Loader2 } from "lucide-react";
+
+interface VariableInputDialogProps {
+  variableName: string;
+  title: string;
+  description: string;
+  placeholder?: string;
+  validator?: string;
+  isOpen: boolean;
+  onComplete: () => void;
+}
+
+export function VariableInputDialog({
+  variableName,
+  title,
+  description,
+  placeholder,
+  validator,
+  isOpen,
+  onComplete,
+}: VariableInputDialogProps) {
+  const [value, setValue] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!value.trim()) {
+      setError("This field is required");
+      return;
+    }
+
+    if (validator) {
+      const regex = new RegExp(validator);
+      if (!regex.test(value)) {
+        setError("Invalid format");
+        return;
+      }
+    }
+
+    setLoading(true);
+    try {
+      const result = await setWorkflowVariable(variableName, value);
+      if (result.success) {
+        onComplete();
+      } else {
+        setError(result.error || "Failed to save");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={() => {}}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="value">Value</Label>
+            <Input
+              id="value"
+              value={value}
+              onChange={(e) => {
+                setValue(e.target.value);
+                setError("");
+              }}
+              placeholder={placeholder}
+              className={error ? "border-red-500" : ""}
+            />
+            {error && <p className="text-sm text-red-500">{error}</p>}
+          </div>
+
+          <Alert>
+            <AlertDescription>
+              This value will be saved and used in subsequent workflow steps.
+            </AlertDescription>
+          </Alert>
+        </div>
+
+        <DialogFooter>
+          <Button onClick={handleSubmit} disabled={loading || !value.trim()}>
+            {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Continue
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/app/components/workflow/workflow-steps.tsx
+++ b/app/components/workflow/workflow-steps.tsx
@@ -11,12 +11,14 @@ interface WorkflowStepsProps {
     google: { authenticated: boolean; scopes: string[] };
     microsoft: { authenticated: boolean; scopes: string[] };
   };
+  variables: Record<string, string>;
 }
 
 export function WorkflowSteps({
   workflow,
   stepStatuses,
   authStatus,
+  variables,
 }: WorkflowStepsProps) {
   // Calculate completed steps
   const completedSteps = new Set(
@@ -77,6 +79,7 @@ export function WorkflowSteps({
             status={status}
             canExecute={canExecute}
             isAuthValid={isAuthValid}
+            variables={variables}
           />
         );
       })}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -88,6 +88,7 @@ export default async function WorkflowPage({ searchParams }: PageProps) {
                   workflow={workflow}
                   stepStatuses={stepStatuses}
                   authStatus={auth}
+                  variables={variables}
                 />
               </section>
             </div>


### PR DESCRIPTION
## Summary
- add ManualStepGuide component with checkboxes, copy buttons and tips
- create ManualStepDialog wrapper
- add VariableInputDialog component
- integrate manual dialog into StepCard
- plumb workflow variables through WorkflowSteps and page

## Testing
- `pnpm lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68474a2c18808322a75cd12a15dffe2c