### PR TITLE
Add token expiration handling

### DIFF
--- a/app/components/workflow/auth-status.tsx
+++ b/app/components/workflow/auth-status.tsx
@@ -5,12 +5,15 @@ import { Button } from "../ui/button";
 import { AlertOctagonIcon, BadgeCheckIcon } from "lucide-react";
 import Link from "next/link";
 import { WILDCARD_SUFFIX_LENGTH } from "@/app/lib/workflow/constants";
+import { TokenStatus } from "./token-status";
 
 interface AuthStatusProps {
   provider: "google" | "microsoft";
   isAuthenticated: boolean;
   scopes: string[];
   requiredScopes: string[];
+  expiresAt?: number;
+  hasRefreshToken?: boolean;
 }
 
 /**
@@ -78,6 +81,8 @@ export function AuthStatus({
   isAuthenticated,
   scopes,
   requiredScopes,
+  expiresAt,
+  hasRefreshToken,
 }: AuthStatusProps) {
   const displayName = provider === "google" ? "Google" : "Microsoft";
   const hasAllScopes = hasAllRequiredScopes(scopes, requiredScopes);
@@ -115,31 +120,42 @@ export function AuthStatus({
 
   return (
     <div className="flex items-center justify-between p-4 bg-white dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800">
-      <div className="flex items-center gap-3">
-        {isAuthenticated ? (
-          <Badge
-            variant="secondary"
-            className="bg-green-500 text-white dark:bg-blue-600"
-          >
-            <BadgeCheckIcon />
-            All set
-          </Badge>
-        ) : (
-          <Badge
-            variant="secondary"
-            className="bg-yellow-700 text-white dark:bg-blue-600"
-          >
-            <AlertOctagonIcon />
-            Attention
-          </Badge>
+      <div className="flex-1">
+        {isAuthenticated && (
+          <TokenStatus
+            provider={provider}
+            isAuthenticated={isAuthenticated}
+            expiresAt={expiresAt}
+            hasRefreshToken={hasRefreshToken}
+          />
         )}
-        <div>
-          <h3 className="font-medium">{displayName}</h3>
-          {isAuthenticated && (
-            <p className="text-sm text-zinc-500 dark:text-zinc-400">
-              {scopeMessage}
-            </p>
+
+        <div className="flex items-center gap-3">
+          {isAuthenticated ? (
+            <Badge
+              variant="secondary"
+              className="bg-green-500 text-white dark:bg-blue-600"
+            >
+              <BadgeCheckIcon />
+              All set
+            </Badge>
+          ) : (
+            <Badge
+              variant="secondary"
+              className="bg-yellow-700 text-white dark:bg-blue-600"
+            >
+              <AlertOctagonIcon />
+              Attention
+            </Badge>
           )}
+          <div>
+            <h3 className="font-medium">{displayName}</h3>
+            {isAuthenticated && (
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                {scopeMessage}
+              </p>
+            )}
+          </div>
         </div>
       </div>
 

--- a/app/components/workflow/step-card.tsx
+++ b/app/components/workflow/step-card.tsx
@@ -22,6 +22,9 @@ import {
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Card } from "../ui/card";
+import { Alert, AlertDescription } from "../ui/alert";
+
+const JSON_INDENT = 2;
 
 interface StepCardProps {
   step: Step;
@@ -175,6 +178,16 @@ export function StepCard({
               </div>
             </div>
 
+            {!isAuthValid && step.role && effectiveStatus.status === "pending" && (
+              <Alert variant="destructive" className="mt-3">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>
+                  Authentication required. Please re-authenticate with{' '}
+                  {step.role.startsWith('graph') ? 'Microsoft' : 'Google'} to continue.
+                </AlertDescription>
+              </Alert>
+            )}
+
             {(effectiveStatus.error || effectiveStatus.status === "failed") && (
               <div className="mt-3 p-4 bg-red-100 dark:bg-red-900/30 rounded-lg border border-red-200 dark:border-red-800">
                 <div className="flex gap-3">
@@ -301,7 +314,7 @@ export function StepCard({
                                           const responseData =
                                             log.data.response;
                                           const fullUrl = log.data.fullUrl;
-                                          const text = `// ${fullUrl}\nexport default ${JSON.stringify(responseData, null, 2)};`;
+                                          const text = `// ${fullUrl}\nexport default ${JSON.stringify(responseData, null, JSON_INDENT)};`;
                                           navigator.clipboard.writeText(text);
                                         }
                                       }}
@@ -322,11 +335,11 @@ export function StepCard({
                                           const responseData =
                                             log.data.response;
                                           const fullUrl = log.data.fullUrl;
-                                          return `// ${fullUrl}\nexport default ${JSON.stringify(responseData, null, 2)};`;
+                                            return `// ${fullUrl}\nexport default ${JSON.stringify(responseData, null, JSON_INDENT)};`;
                                         }
                                         return typeof log.data === "string"
                                           ? log.data
-                                          : JSON.stringify(log.data, null, 2);
+                                            : JSON.stringify(log.data, null, JSON_INDENT);
                                       })()}
                                     </code>
                                   </pre>

--- a/app/components/workflow/token-status.tsx
+++ b/app/components/workflow/token-status.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { Alert, AlertDescription } from "../ui/alert";
+import { Button } from "../ui/button";
+import { RefreshCw, AlertTriangle, CheckCircle } from "lucide-react";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface TokenStatusProps {
+  provider: "google" | "microsoft";
+  isAuthenticated: boolean;
+  expiresAt?: number;
+  hasRefreshToken?: boolean;
+  onRefresh?: () => Promise<void>;
+}
+
+export function TokenStatus({
+  provider,
+  isAuthenticated,
+  expiresAt,
+  hasRefreshToken,
+  onRefresh
+}: TokenStatusProps) {
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const router = useRouter();
+
+  const MS_IN_MINUTE = 60000;
+  const EXPIRING_SOON_MINUTES = 30;
+  const MINUTES_IN_HOUR = 60;
+  
+  if (!isAuthenticated) return null;
+  
+  const now = Date.now();
+  const isExpired = expiresAt ? now >= expiresAt : false;
+  const expiresIn = expiresAt ? expiresAt - now : 0;
+  const expiresInMinutes = Math.floor(expiresIn / MS_IN_MINUTE);
+  const isExpiringSoon =
+    expiresInMinutes < EXPIRING_SOON_MINUTES && expiresInMinutes > 0;
+  
+  const handleRefresh = async () => {
+    if (!onRefresh) return;
+    
+    setIsRefreshing(true);
+    try {
+      await onRefresh();
+      router.refresh();
+    } catch (error) {
+      console.error("Token refresh failed:", error);
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+  
+  const formatExpiry = () => {
+    if (expiresInMinutes > MINUTES_IN_HOUR) {
+      const hours = Math.floor(expiresInMinutes / MINUTES_IN_HOUR);
+      return `${hours} hour${hours > 1 ? "s" : ""}`;
+    }
+    return `${expiresInMinutes} minute${expiresInMinutes !== 1 ? "s" : ""}`;
+  };
+  
+  if (isExpired) {
+    return (
+      <Alert variant="destructive" className="mb-2">
+        <AlertTriangle className="h-4 w-4" />
+        <AlertDescription className="flex items-center justify-between">
+          <span>Token expired - re-authentication required</span>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => window.location.href = `/api/auth/${provider}`}
+          >
+            Re-authenticate
+          </Button>
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  
+  if (isExpiringSoon) {
+    return (
+      <div className="flex items-center justify-between text-sm text-amber-600 dark:text-amber-400 mb-2">
+        <span>Token expires in {formatExpiry()}</span>
+        {hasRefreshToken && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={handleRefresh}
+            disabled={isRefreshing}
+          >
+            <RefreshCw className={`h-3 w-3 mr-1 ${isRefreshing ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        )}
+      </div>
+    );
+  }
+  
+  return (
+    <div className="flex items-center gap-2 text-sm text-green-600 dark:text-green-400 mb-2">
+      <CheckCircle className="h-3 w-3" />
+      <span>Token valid for {formatExpiry()}</span>
+    </div>
+  );
+}

--- a/app/components/workflow/variable-input-dialog.tsx
+++ b/app/components/workflow/variable-input-dialog.tsx
@@ -14,7 +14,7 @@ import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 import { Alert, AlertDescription } from "../ui/alert";
 import { setWorkflowVariable } from "@/app/actions/workflow-state";
-import { escapeRegExp } from "@/app/lib/utils";
+import { validateVariable } from "@/app/lib/workflow";
 import { Loader2 } from "lucide-react";
 
 interface VariableInputDialogProps {
@@ -46,13 +46,9 @@ export function VariableInputDialog({
       return;
     }
 
-    if (validator) {
-      const sanitizedValidator = escapeRegExp(validator);
-      const regex = new RegExp(sanitizedValidator);
-      if (!regex.test(value)) {
-        setError("Invalid format");
-        return;
-      }
+    if (validator && !validateVariable(value, validator)) {
+      setError("Invalid format");
+      return;
     }
 
     setLoading(true);

--- a/app/components/workflow/workflow-steps.tsx
+++ b/app/components/workflow/workflow-steps.tsx
@@ -8,8 +8,8 @@ interface WorkflowStepsProps {
   workflow: Workflow;
   stepStatuses: Record<string, StepStatus>;
   authStatus: {
-    google: { authenticated: boolean; scopes: string[] };
-    microsoft: { authenticated: boolean; scopes: string[] };
+    google: { authenticated: boolean; scopes: string[]; expiresAt?: number };
+    microsoft: { authenticated: boolean; scopes: string[]; expiresAt?: number };
   };
 }
 
@@ -44,12 +44,23 @@ export function WorkflowSteps({
     const isMicrosoftStep = step.role.startsWith("graph");
 
     if (isGoogleStep && authStatus.google.authenticated) {
-      return requiredScopes.every((scope: string) =>
-        authStatus.google.scopes.includes(scope),
+      const notExpired =
+        !authStatus.google.expiresAt || authStatus.google.expiresAt > Date.now();
+      return (
+        notExpired &&
+        requiredScopes.every((scope: string) =>
+          authStatus.google.scopes.includes(scope),
+        )
       );
     } else if (isMicrosoftStep && authStatus.microsoft.authenticated) {
-      return requiredScopes.every((scope: string) =>
-        authStatus.microsoft.scopes.includes(scope),
+      const notExpired =
+        !authStatus.microsoft.expiresAt ||
+        authStatus.microsoft.expiresAt > Date.now();
+      return (
+        notExpired &&
+        requiredScopes.every((scope: string) =>
+          authStatus.microsoft.scopes.includes(scope),
+        )
       );
     }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -72,12 +72,16 @@ export default async function WorkflowPage({ searchParams }: PageProps) {
                   isAuthenticated={auth.google.authenticated}
                   scopes={auth.google.scopes}
                   requiredScopes={allRequiredGoogleScopes}
+                  expiresAt={auth.google.expiresAt}
+                  hasRefreshToken={auth.google.hasRefreshToken}
                 />
                 <AuthStatus
                   provider="microsoft"
                   isAuthenticated={auth.microsoft.authenticated}
                   scopes={auth.microsoft.scopes}
                   requiredScopes={allRequiredMicrosoftScopes}
+                  expiresAt={auth.microsoft.expiresAt}
+                  hasRefreshToken={auth.microsoft.hasRefreshToken}
                 />
               </section>
 


### PR DESCRIPTION
## Summary
- refresh and persist tokens when using api client
- expose token expiry status in workflow data and auth status
- display token validity using new TokenStatus component
- auto-refresh tokens on workflow load
- add manual token refresh action
- show reauth alerts on step cards when token expired
- fix lint issues in new code

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68475cf262a083228392fd26a9abaefa