### PR TITLE
Fix workflow auth bugs and improve reliability

### DIFF
--- a/app/actions/workflow-data.ts
+++ b/app/actions/workflow-data.ts
@@ -86,16 +86,21 @@ async function reconstituteStepStatuses(
 
   const isAuthMet = (step: Step): boolean => {
     if (!step.role) return true;
-    const requiredScopes = Object.prototype.hasOwnProperty.call(workflow.roles, step.role)
-      ? workflow.roles[step.role as keyof typeof workflow.roles]
-      : [];
+    const requiredScopes = workflow.roles[step.role as keyof typeof workflow.roles] || [];
     const isGoogleStep = step.role.startsWith("dir") || step.role.startsWith("ci");
     const isMicrosoftStep = step.role.startsWith("graph");
+
     if (isGoogleStep && tokens.google) {
-      return !isTokenExpired(tokens.google) && requiredScopes.every((s) => tokens.google!.scope.includes(s));
+      return (
+        !isTokenExpired(tokens.google) &&
+        requiredScopes.every((s) => tokens.google!.scope.includes(s))
+      );
     }
     if (isMicrosoftStep && tokens.microsoft) {
-      return !isTokenExpired(tokens.microsoft) && requiredScopes.every((s) => tokens.microsoft!.scope.includes(s));
+      return (
+        !isTokenExpired(tokens.microsoft) &&
+        requiredScopes.every((s) => tokens.microsoft!.scope.includes(s))
+      );
     }
     return false;
   };
@@ -181,13 +186,13 @@ export async function getWorkflowData(
     stepStatuses: Object.fromEntries(stepStatusesMap),
     auth: {
       google: {
-        authenticated: !!googleToken,
+        authenticated: !!googleToken && !isTokenExpired(googleToken),
         scopes: googleToken?.scope || [],
         expiresAt: googleToken?.expiresAt,
         hasRefreshToken: !!googleToken?.refreshToken,
       },
       microsoft: {
-        authenticated: !!microsoftToken,
+        authenticated: !!microsoftToken && !isTokenExpired(microsoftToken),
         scopes: microsoftToken?.scope || [],
         expiresAt: microsoftToken?.expiresAt,
         hasRefreshToken: !!microsoftToken?.refreshToken,
@@ -205,13 +210,13 @@ export async function getAuthStatus(): Promise<AuthState> {
 
   return {
     google: {
-      authenticated: !!googleToken,
+      authenticated: !!googleToken && !isTokenExpired(googleToken),
       scopes: googleToken?.scope || [],
       expiresAt: googleToken?.expiresAt,
       hasRefreshToken: !!googleToken?.refreshToken,
     },
     microsoft: {
-      authenticated: !!microsoftToken,
+      authenticated: !!microsoftToken && !isTokenExpired(microsoftToken),
       scopes: microsoftToken?.scope || [],
       expiresAt: microsoftToken?.expiresAt,
       hasRefreshToken: !!microsoftToken?.refreshToken,

--- a/app/actions/workflow-execution.ts
+++ b/app/actions/workflow-execution.ts
@@ -158,6 +158,13 @@ async function handleActionExecution(
 
   applyExtracts(action, response, variables, extractedVariables, onLog);
   Object.assign(extractedVariables, capturedValues);
+  Object.assign(variables, extractedVariables, capturedValues);
+  console.log('[Variable Update] After extraction:', {
+    action: action.use,
+    extractedVariables,
+    capturedValues,
+    allVariables: { ...variables, ...extractedVariables, ...capturedValues },
+  });
 
   if (areOutputsMissing(step, extractedVariables)) {
     onLog({

--- a/app/actions/workflow-state.ts
+++ b/app/actions/workflow-state.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { StepStatus, parseWorkflow } from "@/app/lib/workflow";
+import { parseWorkflow } from "@/app/lib/workflow";
 import { getToken, setToken } from "@/app/lib/auth/tokens";
 import { refreshAccessToken } from "@/app/lib/auth/oauth";
 

--- a/app/components/error-boundary.tsx
+++ b/app/components/error-boundary.tsx
@@ -1,0 +1,44 @@
+"use client";
+import React from "react";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("[ErrorBoundary]", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4 bg-red-50 dark:bg-red-950/30 rounded border border-red-200 dark:border-red-700">
+          <h2 className="font-medium text-red-800 dark:text-red-200 mb-2">Something went wrong.</h2>
+          <pre className="text-xs text-red-700 dark:text-red-300 whitespace-pre-wrap">
+            {this.state.error?.message}
+          </pre>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/app/components/workflow/auth-status.tsx
+++ b/app/components/workflow/auth-status.tsx
@@ -2,7 +2,7 @@
 
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
-import { AlertOctagonIcon, BadgeCheckIcon } from "lucide-react";
+import { BadgeCheckIcon } from "lucide-react";
 import Link from "next/link";
 import { WILDCARD_SUFFIX_LENGTH } from "@/app/lib/workflow/constants";
 import { TokenStatus } from "./token-status";
@@ -103,20 +103,32 @@ export function AuthStatus({
   );
 
   let actionElement: React.ReactNode;
+  const isExpired = expiresAt ? Date.now() >= expiresAt : false;
+
   if (!isAuthenticated) {
     actionElement = (
       <Button asChild>
         <Link href={authUrl}>Authenticate</Link>
       </Button>
     );
-  } else if (!hasAllScopes) {
+  } else if (isExpired) {
     actionElement = (
-      <Button asChild color="amber">
+      <Button asChild>
         <Link href={authUrl}>Re-authenticate</Link>
       </Button>
     );
+  } else if (!hasAllScopes) {
+    actionElement = (
+      <Button asChild variant="secondary">
+        <Link href={authUrl}>Update permissions</Link>
+      </Button>
+    );
   } else {
-    actionElement = <Badge color="green">Connected</Badge>;
+    actionElement = (
+      <Badge variant="secondary" className="bg-green-500 text-white">
+        <BadgeCheckIcon className="h-4 w-4" />
+      </Badge>
+    );
   }
 
   return (
@@ -138,26 +150,9 @@ export function AuthStatus({
           )}
 
         <div className="flex items-center gap-3">
-          {isAuthenticated ? (
-            <Badge
-              variant="secondary"
-              className="bg-green-500 text-white dark:bg-blue-600"
-            >
-              <BadgeCheckIcon />
-              All set
-            </Badge>
-          ) : (
-            <Badge
-              variant="secondary"
-              className="bg-yellow-700 text-white dark:bg-blue-600"
-            >
-              <AlertOctagonIcon />
-              Attention
-            </Badge>
-          )}
           <div>
             <h3 className="font-medium">{displayName}</h3>
-            {isAuthenticated && (
+            {isAuthenticated && !isExpired && (
               <p className="text-sm text-zinc-500 dark:text-zinc-400">
                 {scopeMessage}
               </p>

--- a/app/components/workflow/step-card.tsx
+++ b/app/components/workflow/step-card.tsx
@@ -260,7 +260,7 @@ export function StepCard({
           </div>
 
           {effectiveStatus.status === "completed" &&
-            effectiveStatus.variables?.generatedPassword &&
+            variables.generatedPassword &&
             step.name === "Create Service Account for Microsoft" && (
               <div className="mt-3">
                 <PasswordDisplay

--- a/app/lib/api/client.ts
+++ b/app/lib/api/client.ts
@@ -81,10 +81,10 @@ async function handleAuthenticatedRequest(options: ApiRequestOptions): Promise<u
         `[API Client] Token refresh failed for ${provider}:`,
         refreshError,
       );
-
-      // Throw a specific error that indicates re-authentication is needed
+      const errorMessage =
+        refreshError instanceof Error ? refreshError.message : "Unknown error";
       throw new Error(
-        `Authentication expired for ${provider}. Please re-authenticate.`,
+        `Authentication expired for ${provider}. ${errorMessage}. Please re-authenticate manually.`,
       );
     }
   }

--- a/app/lib/auth/cookie-utils.ts
+++ b/app/lib/auth/cookie-utils.ts
@@ -1,7 +1,7 @@
 import { cookies } from "next/headers";
 import { WORKFLOW_CONSTANTS, COOKIE_METADATA_SIZES } from "../workflow";
 
-// Safe limit is around 4093 bytes per cookie, but we'll use constant to leave room for cookie metadata
+// Safe limit is around 4093 bytes per cookie. We use a slightly lower constant for safety.
 const MAX_COOKIE_SIZE = WORKFLOW_CONSTANTS.MAX_COOKIE_SIZE;
 const CHUNK_DELIMITER = ".chunk.";
 
@@ -41,6 +41,13 @@ export async function setChunkedCookie(
 
   // First, clear any existing chunks for this cookie
   await clearChunkedCookie(name);
+
+  const estimatedSize = estimateCookieSize(name, value, options);
+  if (estimatedSize > MAX_COOKIE_SIZE) {
+    console.warn(
+      `[Cookie Utils] ${name} exceeds safe cookie size (${estimatedSize} > ${MAX_COOKIE_SIZE}). Splitting into chunks.`,
+    );
+  }
 
   const chunks = splitIntoChunks(value);
 

--- a/app/lib/auth/oauth.ts
+++ b/app/lib/auth/oauth.ts
@@ -154,9 +154,16 @@ export function validateScopes(
 }
 
 export function isTokenExpired(token: Token): boolean {
-  return (
-    Date.now() >= token.expiresAt - WORKFLOW_CONSTANTS.TOKEN_REFRESH_BUFFER_MS
+  if (!token.expiresAt) return true; // Treat missing expiry as expired
+  const bufferMs = WORKFLOW_CONSTANTS.TOKEN_REFRESH_BUFFER_MS;
+  const expiryTime = token.expiresAt - bufferMs;
+  const now = Date.now();
+  console.log(
+    `[Token Expiry] Token expires at: ${new Date(token.expiresAt).toISOString()}, Current time: ${new Date(
+      now,
+    ).toISOString()}, Is expired: ${now >= expiryTime}`,
   );
+  return now >= expiryTime;
 }
 
 export {

--- a/app/lib/workflow/constants.ts
+++ b/app/lib/workflow/constants.ts
@@ -76,7 +76,7 @@ export const WORKFLOW_CONSTANTS = {
   MAX_WORKFLOW_ITERATIONS: 2,
 
   // Size constants
-  MAX_COOKIE_SIZE: 3900,
+  MAX_COOKIE_SIZE: 3800,
 
   // API constants
   SYNC_INTERVAL: "PT40M", // 40 minutes in ISO 8601

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { getWorkflowData } from "./actions/workflow-data";
 import { AuthStatus } from "./components/workflow/auth-status";
 import { WorkflowSteps } from "./components/workflow/workflow-steps";
+import { ErrorBoundary } from "./components/error-boundary";
 import { VariableViewer } from "./components/workflow/variable-viewer";
 import { DebugTools } from "./components/workflow/debug-tools";
 import { Alert, AlertDescription, AlertTitle } from "./components/ui/alert";
@@ -88,12 +89,14 @@ export default async function WorkflowPage({ searchParams }: PageProps) {
               {/* Workflow Steps */}
               <section className="space-y-4">
                 <h2 className="text-lg font-medium">Workflow Steps</h2>
-                <WorkflowSteps
-                  workflow={workflow}
-                  stepStatuses={stepStatuses}
-                  authStatus={auth}
-                  variables={variables}
-                />
+                <ErrorBoundary>
+                  <WorkflowSteps
+                    workflow={workflow}
+                    stepStatuses={stepStatuses}
+                    authStatus={auth}
+                    variables={variables}
+                  />
+                </ErrorBoundary>
               </section>
             </div>
 

--- a/workflow.json
+++ b/workflow.json
@@ -635,7 +635,7 @@
               "{\"ClaimsMappingPolicy\":{\"Version\":1,\"IncludeBasicClaimSet\":true,\"ClaimsMapping\":{\"email\":{\"source\":\"user\",\"id\":\"mail\"}}}}"
             ]
           },
-          "outputs": {
+          "extract": {
             "claimsPolicyId": "$.id"
           }
         },


### PR DESCRIPTION
## Summary
- extract claims mapping policy id correctly
- improve auth status badge logic and expiry handling
- log token expiry and treat missing expiry as expired
- validate tokens when reconstructing workflow data
- capture API-generated variables correctly
- streamline cookie chunking with size warnings
- better token refresh error messages
- add error boundary around workflow steps
- update password display check
- lower MAX_COOKIE_SIZE for safety

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847746368d48322a84ba9e407dc6a4e