### PR TITLE
BUG: Generated password extraction logic is backwards

### DIFF
--- a/app/components/workflow/workflow-steps.tsx
+++ b/app/components/workflow/workflow-steps.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { StepCard } from "./step-card";
 import type { Workflow, Step, StepStatus } from "@/app/lib/workflow";
+import { isTokenExpired } from "@/app/lib/auth/oauth";
 
 interface WorkflowStepsProps {
   workflow: Workflow;
@@ -47,7 +48,12 @@ export function WorkflowSteps({
 
     if (isGoogleStep && authStatus.google.authenticated) {
       const notExpired =
-        !authStatus.google.expiresAt || authStatus.google.expiresAt > Date.now();
+        !authStatus.google.expiresAt ||
+        !isTokenExpired({
+          accessToken: "",
+          expiresAt: authStatus.google.expiresAt || 0,
+          scope: [],
+        });
       return (
         notExpired &&
         requiredScopes.every((scope: string) =>
@@ -57,7 +63,11 @@ export function WorkflowSteps({
     } else if (isMicrosoftStep && authStatus.microsoft.authenticated) {
       const notExpired =
         !authStatus.microsoft.expiresAt ||
-        authStatus.microsoft.expiresAt > Date.now();
+        !isTokenExpired({
+          accessToken: "",
+          expiresAt: authStatus.microsoft.expiresAt || 0,
+          scope: [],
+        });
       return (
         notExpired &&
         requiredScopes.every((scope: string) =>

--- a/app/lib/workflow/constants.ts
+++ b/app/lib/workflow/constants.ts
@@ -23,7 +23,7 @@ export const PROVIDERS = {
   GOOGLE: "google",
   MICROSOFT: "microsoft",
 } as const;
-export type Provider = typeof PROVIDERS[keyof typeof PROVIDERS];
+export type Provider = (typeof PROVIDERS)[keyof typeof PROVIDERS];
 
 // Status values
 export const STATUS_VALUES = {
@@ -74,7 +74,11 @@ export const COOKIE_METADATA_SIZES = {
 export const WORKFLOW_CONSTANTS = {
   // Time constants (replacing magic numbers)
   OAUTH_STATE_TTL_MS:
-    DAYS_IN_MONTH * HOURS_IN_DAY * MINUTES_IN_HOUR * SECONDS_IN_MINUTE * MS_IN_SECOND,
+    DAYS_IN_MONTH *
+    HOURS_IN_DAY *
+    MINUTES_IN_HOUR *
+    SECONDS_IN_MINUTE *
+    MS_IN_SECOND,
   TOKEN_REFRESH_BUFFER_MS: 300000, // 5 minutes
   TOKEN_COOKIE_MAX_AGE:
     DAYS_IN_MONTH * HOURS_IN_DAY * MINUTES_IN_HOUR * SECONDS_IN_MINUTE, // 30 days
@@ -103,6 +107,11 @@ export const WORKFLOW_CONSTANTS = {
 
   // Size constants
   MAX_COOKIE_SIZE: 3800,
+
+  // Cookie names and TTL
+  VARIABLES_COOKIE_NAME: "workflow_vars",
+  VARIABLES_COOKIE_MAX_AGE:
+    DAYS_IN_MONTH * HOURS_IN_DAY * MINUTES_IN_HOUR * SECONDS_IN_MINUTE,
 
   // API constants
   SYNC_INTERVAL: "PT40M", // 40 minutes in ISO 8601

--- a/app/lib/workflow/index.ts
+++ b/app/lib/workflow/index.ts
@@ -4,3 +4,4 @@ export * from "./variables";
 export * from "./checkers";
 export * from "./engine";
 export * from "./constants";
+export * from "./variables-store";


### PR DESCRIPTION
## Summary
- capture generated password from current execution
- pass captured values to the extraction helper
- use constants instead of magic strings
- persist workflow variables across steps via encrypted cookies
- handle verification errors during state reconstruction
- standardize token expiry checks in the steps UI

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68479e70e1208322bd97788c3315a90c