### PR TITLE
Improve variable persistence and error reporting

### DIFF
--- a/app/actions/workflow-data.ts
+++ b/app/actions/workflow-data.ts
@@ -18,7 +18,7 @@ import {
   STATUS_VALUES,
   VARIABLE_KEYS,
 } from "@/app/lib/workflow/constants";
-import { getStoredVariables } from "@/app/lib/workflow";
+import { getStoredVariables, setStoredVariables } from "@/app/lib/workflow";
 import { runStepActions } from "./workflow-execution";
 import { refreshWorkflowState } from "./workflow-state";
 
@@ -223,6 +223,11 @@ export async function getWorkflowData(
 
   const { stepStatuses: stepStatusesMap, variables: reconstructedVariables } =
     await reconstituteStepStatuses(workflow, variables, tokens);
+
+  // Persist variables reconstructed from verification so they are available
+  // during subsequent executions. This acts as a central variable store
+  // ensuring all extracted values survive between requests.
+  await setStoredVariables(reconstructedVariables);
 
   console.log(
     `[Initial Load] Final step statuses:`,

--- a/app/actions/workflow-execution.ts
+++ b/app/actions/workflow-execution.ts
@@ -115,7 +115,8 @@ function parseApiError(error: unknown): {
       if (isStructuredApiError(parsed)) {
         apiError = parsed;
         const err = parsed.error;
-        errorMessage = `${err.code}: ${err.message}`;
+        // Include all available fields from the API error to aid debugging
+        errorMessage = JSON.stringify(err);
         if (
           err.code === WORKFLOW_CONSTANTS.HTTP_STATUS.UNAUTHORIZED ||
           err.status === "UNAUTHENTICATED" ||

--- a/app/lib/workflow/variables-store.ts
+++ b/app/lib/workflow/variables-store.ts
@@ -4,7 +4,8 @@ import {
   clearChunkedCookie,
 } from "../auth/cookie-utils";
 import { encrypt, decrypt } from "../auth/crypto";
-import { WORKFLOW_CONSTANTS, LogEntry } from "./constants";
+import { WORKFLOW_CONSTANTS } from "./constants";
+import { LogEntry } from "./types";
 
 const COOKIE_OPTIONS = {
   httpOnly: true,

--- a/app/lib/workflow/variables.ts
+++ b/app/lib/workflow/variables.ts
@@ -1,6 +1,10 @@
 import { JSONPath } from "jsonpath-plus";
 import { randomBytes } from "crypto";
-import { EXPECTED_ARG_COUNT_PAIR, WILDCARD_SUFFIX_LENGTH } from "./constants";
+import {
+  EXPECTED_ARG_COUNT_PAIR,
+  WILDCARD_SUFFIX_LENGTH,
+  VARIABLE_KEYS,
+} from "./constants";
 
 function hasProp(obj: unknown, prop: string): obj is Record<string, unknown> {
   return typeof obj === "object" && obj !== null && prop in obj;
@@ -67,7 +71,7 @@ export function substituteVariables(
           expression.startsWith('generatePassword(') &&
           options.captureGenerated
         ) {
-          options.captureGenerated.generatedPassword = result;
+          options.captureGenerated[VARIABLE_KEYS.GENERATED_PASSWORD] = result;
         }
         return result;
       } catch (error) {


### PR DESCRIPTION
## Summary
- persist reconstructed variables after verification to preserve state
- include full API error details when parsing failures
- update typing import for variable store

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6847ae902cbc8322a0e51e47aa93001d