### PR TITLE
Fix workflow step status checking

### DIFF
--- a/app/actions/workflow-execution.ts
+++ b/app/actions/workflow-execution.ts
@@ -508,7 +508,7 @@ export async function executeWorkflowStep(stepName: string): Promise<{
     await setStoredVariables(updatedVariables);
 
     if (
-      status.status === "completed" &&
+      status.status === STATUS_VALUES.COMPLETED &&
       Object.keys(updatedVariables).length >
         Object.keys(currentData.variables).length
     ) {
@@ -530,7 +530,7 @@ export async function executeWorkflowStep(stepName: string): Promise<{
     revalidatePath("/");
 
     return {
-      success: status.status === "completed",
+      success: status.status === STATUS_VALUES.COMPLETED,
       status,
       variables: updatedVariables,
     };


### PR DESCRIPTION
## Summary
- use `STATUS_VALUES.COMPLETED` instead of magic string

## Testing
- `npm run lint`
- `npx -y tsx verify-fixes.ts`


------
https://chatgpt.com/codex/tasks/task_e_68483f4df1148322877a5e5431f47c7b