### PR TITLE
Handle manualStepsState parse errors

### DIFF
--- a/app/actions/workflow-data.ts
+++ b/app/actions/workflow-data.ts
@@ -94,9 +94,17 @@ async function reconstituteStepStatuses(
 }> {
   const stepStatuses = new Map<string, StepStatus>();
   const workingVariables = { ...variables };
-  const manualData = workingVariables.manualStepsState
-    ? JSON.parse(workingVariables.manualStepsState)
-    : { completed: [], completedAt: {} } as { completed: string[]; completedAt: Record<string, number> };
+  let manualData: { completed: string[]; completedAt: Record<string, number> } = {
+    completed: [],
+    completedAt: {},
+  };
+  if (workingVariables.manualStepsState) {
+    try {
+      manualData = JSON.parse(workingVariables.manualStepsState);
+    } catch (error) {
+      console.warn("Failed to parse manualStepsState", error);
+    }
+  }
   const manualCompleted = manualData.completed;
 
   const pendingStatus: StepStatus = { status: STATUS_VALUES.PENDING, logs: [] };


### PR DESCRIPTION
## Summary
- handle JSON.parse failures when reading manualStepsState

## Testing
- `npm run lint`
- `node verify-fixes.ts` *(fails: Unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_e_68483f552d3483229e63e8fc221b89fd