### PR TITLE
Fix simple path prefix stripping

### DIFF
--- a/app/lib/workflow/variables.ts
+++ b/app/lib/workflow/variables.ts
@@ -2,7 +2,6 @@ import { JSONPath } from "jsonpath-plus";
 import { randomBytes } from "crypto";
 import {
   EXPECTED_ARG_COUNT_PAIR,
-  WILDCARD_SUFFIX_LENGTH,
   VARIABLE_KEYS,
 } from "./constants";
 import {
@@ -379,7 +378,10 @@ function evaluatePredicatePath(obj: unknown, path: string): unknown {
 
 function evaluateSimplePath(obj: unknown, path: string): unknown {
   if (path.startsWith("$")) {
-    path = path.substring(WILDCARD_SUFFIX_LENGTH);
+    path = path.slice(1);
+    if (path.startsWith(".")) {
+      path = path.slice(1);
+    }
   }
 
   const parts = path.split(".");


### PR DESCRIPTION
## Summary
- remove unused wildcard constant import
- handle paths starting with `$` or `$.` in `evaluateSimplePath`

## Testing
- `npm run lint`
- `npx tsx verify-fixes.ts`


------
https://chatgpt.com/codex/tasks/task_e_68483f5ea96c8322b0128848f77f7775