### PR TITLE
Fix fallback variable checks

### DIFF
--- a/app/actions/workflow-execution.ts
+++ b/app/actions/workflow-execution.ts
@@ -148,16 +148,16 @@ async function handleActionExecution(
     message: `[DEBUG] Variables available for ${action.use}: ${Object.keys(variables).join(", ")}`,
   });
 
-  if (endpoint.path && !action.fallback) {
-    const missingVars = extractMissingVariables(endpoint.path, variables);
-    if (missingVars.length > 0) {
-      onLog({
-        timestamp: Date.now(),
-        level: "info",
-        message: `Skipping action ${action.use} - missing variables: ${missingVars.join(", ")}`,
-      });
-      return { success: false, extractedVariables };
-    }
+  const missingVars = endpoint.path
+    ? extractMissingVariables(endpoint.path, variables)
+    : [];
+  if (missingVars.length > 0) {
+    onLog({
+      timestamp: Date.now(),
+      level: "info",
+      message: `Skipping action ${action.use} - missing variables: ${missingVars.join(", ")}`,
+    });
+    return { success: false, extractedVariables };
   }
 
   const generatedCaptures: Record<string, string> = {};


### PR DESCRIPTION
## Summary
- skip actions with missing variables even when they are fallback
- run lint and verification scripts

## Testing
- `npm run lint`
- `npx tsx verify-fixes.ts`


------
https://chatgpt.com/codex/tasks/task_e_68483f608bb88322bc41dd4c1f45fa71