### PR TITLE
Use OAuth config constants in token utilities

### DIFF
--- a/app/lib/auth/oauth-server.ts
+++ b/app/lib/auth/oauth-server.ts
@@ -1,4 +1,4 @@
-import { env } from "@/app/env";
+import { env } from "../../env";
 import { OAuthConfig, Provider, Token } from "../workflow";
 import {
   MS_IN_SECOND,

--- a/test-utils/tokenUtils.ts
+++ b/test-utils/tokenUtils.ts
@@ -1,34 +1,16 @@
 import crypto from "crypto";
 import { GoogleAuth } from "google-auth-library";
-const googleScopes = [
-  "openid",
-  "email",
-  "profile",
-  "https://www.googleapis.com/auth/admin.directory.user",
-  "https://www.googleapis.com/auth/admin.directory.orgunit",
-  "https://www.googleapis.com/auth/admin.directory.domain",
-  "https://www.googleapis.com/auth/admin.directory.rolemanagement",
-  "https://www.googleapis.com/auth/cloud-identity.inboundsso",
-  "https://www.googleapis.com/auth/siteverification",
-  "https://www.googleapis.com/auth/admin.directory.rolemanagement",
-];
+import {
+  googleOAuthConfig,
+  microsoftOAuthConfig,
+} from "../app/lib/auth/oauth-server";
 
-const microsoftScopes = [
-  "openid",
-  "profile",
-  "email",
-  "offline_access",
-  "User.Read",
-  "Directory.Read.All",
-  "Application.ReadWrite.All",
-  "AppRoleAssignment.ReadWrite.All",
-  "Policy.ReadWrite.ApplicationConfiguration",
-  "offline_access",
-];
+const googleScopes = googleOAuthConfig.scopes;
 
-const googleTokenUrl = "https://oauth2.googleapis.com/token";
-const microsoftTokenUrl =
-  "https://login.microsoftonline.com/organizations/oauth2/v2.0/token";
+const microsoftScopes = microsoftOAuthConfig.scopes;
+
+const googleTokenUrl = googleOAuthConfig.tokenUrl;
+const microsoftTokenUrl = microsoftOAuthConfig.tokenUrl;
 
 interface GoogleKey {
   client_email: string;


### PR DESCRIPTION
## Summary
- import OAuth scope/token config for tests instead of duplicating
- use relative import in oauth server to avoid path alias issues in Jest

## Testing
- `pnpm test` *(fails: fetch failed during global setup)*

------
https://chatgpt.com/codex/tasks/task_e_684b4db5a7548322acf416831fdf4f38