### PR TITLE
Add live API test resource tracker

### DIFF
--- a/__tests__/setup/live-api-context.ts
+++ b/__tests__/setup/live-api-context.ts
@@ -1,0 +1,102 @@
+import { ApiContext } from '@/app/lib/workflow/endpoints/utils';
+import { globalTracker } from './test-resource-tracker';
+
+interface LiveApiOptions {
+  trackCreatedResources?: boolean;
+  googleToken: string;
+  microsoftToken: string;
+}
+
+export function createLiveApiContext(options: LiveApiOptions): ApiContext {
+  const { googleToken, microsoftToken, trackCreatedResources = true } = options;
+
+  return {
+    request: async (connection, method, path, opts) => {
+      // Determine which token to use
+      const token = connection.startsWith('graph') ? microsoftToken : 
+                   connection.startsWith('google') ? googleToken : '';
+      
+      // Build full URL
+      const baseUrls: Record<string, string> = {
+        googleAdmin: 'https://admin.googleapis.com/admin/directory/v1',
+        googleCI: 'https://cloudidentity.googleapis.com/v1',
+        graphGA: 'https://graph.microsoft.com/v1.0',
+        graphBeta: 'https://graph.microsoft.com/beta',
+        public: 'https://login.microsoftonline.com'
+      };
+      
+      const baseUrl = baseUrls[connection] || '';
+      const url = new URL(path, baseUrl);
+      
+      // Add query params
+      if (opts?.query) {
+        Object.entries(opts.query).forEach(([key, value]) => {
+          if (value !== undefined) {
+            url.searchParams.append(key, value);
+          }
+        });
+      }
+
+      console.log(`[API] ${method} ${url.toString()}`);
+
+      // Make the request
+      const response = await fetch(url.toString(), {
+        method,
+        headers: {
+          'Authorization': token ? `Bearer ${token}` : '',
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        },
+        body: opts?.body ? JSON.stringify(opts.body) : undefined
+      });
+
+      const responseText = await response.text();
+      let responseData: any;
+      
+      try {
+        responseData = JSON.parse(responseText);
+      } catch {
+        responseData = responseText;
+      }
+
+      if (!response.ok) {
+        console.error(`[API ERROR] ${method} ${url.toString()}: ${response.status}`);
+        console.error('[API ERROR]', responseData);
+        throw new Error(`API error: ${response.status} - ${JSON.stringify(responseData)}`);
+      }
+
+      // Track created resources
+      if (trackCreatedResources && method === 'POST' && response.status === 201) {
+        await trackResourceFromResponse(connection, path, responseData);
+      }
+
+      return responseData;
+    }
+  };
+}
+
+async function trackResourceFromResponse(connection: string, path: string, response: any) {
+  // Detect resource type and ID from response
+  if (connection === 'googleAdmin') {
+    if (path.includes('/users') && response.id) {
+      await globalTracker.track('google_user', response.primaryEmail || response.id);
+    } else if (path.includes('/orgunits') && response.orgUnitId) {
+      await globalTracker.track('google_ou', response.orgUnitPath || response.orgUnitId);
+    } else if (path.includes('/roles') && response.roleId) {
+      await globalTracker.track('google_role', response.roleId);
+    }
+  } else if (connection === 'googleCI') {
+    if (path.includes('/inboundSamlSsoProfiles') && response.response?.name) {
+      await globalTracker.track('google_saml_profile', response.response.name);
+    }
+  } else if (connection.startsWith('graph')) {
+    if (path.includes('/applicationTemplates') && response.application?.id) {
+      await globalTracker.track('microsoft_app', response.application.id);
+      if (response.servicePrincipal?.id) {
+        await globalTracker.track('microsoft_sp', response.servicePrincipal.id);
+      }
+    } else if (path.includes('/policies') && response.id) {
+      await globalTracker.track('microsoft_policy', response.id);
+    }
+  }
+}

--- a/__tests__/setup/test-resource-tracker.test.ts
+++ b/__tests__/setup/test-resource-tracker.test.ts
@@ -1,0 +1,49 @@
+import { join } from 'path';
+import { access } from 'fs/promises';
+import { fileURLToPath } from 'url';
+import { TestResourceTracker } from './test-resource-tracker';
+import { jest } from '@jest/globals';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const trackingFile = join(__dirname, '../../.test-resources.json');
+
+describe('TestResourceTracker', () => {
+  let tracker: TestResourceTracker;
+  beforeEach(async () => {
+    tracker = new TestResourceTracker();
+    // ensure clean file
+    await tracker.load();
+    const res = tracker.getResources();
+    if (res.length) {
+      // remove file for isolation
+      await tracker.cleanup('token', 'token').catch(() => {});
+    }
+  });
+
+  afterEach(async () => {
+    await tracker.cleanup('token', 'token').catch(() => {});
+  });
+
+  it('tracks resources and persists to disk', async () => {
+    await tracker.track('google_user', 'user@example.com');
+    await access(trackingFile); // should exist
+    const resources = tracker.getResources();
+    expect(resources.length).toBe(1);
+    expect(resources[0].id).toBe('user@example.com');
+  });
+
+  it('loads and cleans up resources', async () => {
+    await tracker.track('google_user', 'delete@example.com');
+    // mock fetch to avoid real network
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      text: async () => ''
+    });
+    globalThis.fetch = fetchMock as any;
+
+    await tracker.cleanup('g', 'm');
+
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});

--- a/__tests__/setup/test-resource-tracker.ts
+++ b/__tests__/setup/test-resource-tracker.ts
@@ -1,0 +1,119 @@
+import { writeFile, readFile, unlink } from 'fs/promises';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+interface TrackedResource {
+  type: 'google_user' | 'google_ou' | 'google_role' | 'google_saml_profile' |
+        'microsoft_app' | 'microsoft_sp' | 'microsoft_policy';
+  id: string;
+  metadata?: Record<string, any>;
+  createdAt: number;
+}
+
+export class TestResourceTracker {
+  private resources: TrackedResource[] = [];
+  private trackingFile = join(__dirname, '../../.test-resources.json');
+
+  async track(type: TrackedResource['type'], id: string, metadata?: Record<string, any>) {
+    const resource: TrackedResource = {
+      type,
+      id,
+      metadata,
+      createdAt: Date.now()
+    };
+    this.resources.push(resource);
+    await this.persist();
+    console.log(`[TRACKED] ${type}: ${id}`);
+  }
+
+  async persist() {
+    await writeFile(this.trackingFile, JSON.stringify(this.resources, null, 2));
+  }
+
+  async load() {
+    try {
+      const data = await readFile(this.trackingFile, 'utf-8');
+      this.resources = JSON.parse(data);
+    } catch {
+      this.resources = [];
+    }
+  }
+
+  async cleanup(googleToken: string, microsoftToken: string) {
+    await this.load();
+    console.log(`[CLEANUP] Found ${this.resources.length} resources to clean up`);
+    
+    // Process in reverse order (delete dependents first)
+    for (const resource of this.resources.reverse()) {
+      try {
+        await this.deleteResource(resource, googleToken, microsoftToken);
+        console.log(`[CLEANUP] \u2713 Deleted ${resource.type}: ${resource.id}`);
+      } catch (error) {
+        console.error(`[CLEANUP] \u2717 Failed to delete ${resource.type}: ${resource.id}`, error);
+      }
+    }
+    
+    // Clear tracking file
+    await unlink(this.trackingFile).catch(() => {});
+  }
+
+  private async deleteResource(resource: TrackedResource, googleToken: string, microsoftToken: string) {
+    const deleteHandlers: Record<TrackedResource['type'], () => Promise<void>> = {
+      google_user: async () => {
+        await fetch(
+          `https://admin.googleapis.com/admin/directory/v1/users/${encodeURIComponent(resource.id)}`,
+          { method: 'DELETE', headers: { Authorization: `Bearer ${googleToken}` } }
+        );
+      },
+      google_ou: async () => {
+        await fetch(
+          `https://admin.googleapis.com/admin/directory/v1/customer/my_customer/orgunits/${encodeURIComponent(resource.id)}`,
+          { method: 'DELETE', headers: { Authorization: `Bearer ${googleToken}` } }
+        );
+      },
+      google_role: async () => {
+        await fetch(
+          `https://admin.googleapis.com/admin/directory/v1/customer/my_customer/roles/${resource.id}`,
+          { method: 'DELETE', headers: { Authorization: `Bearer ${googleToken}` } }
+        );
+      },
+      google_saml_profile: async () => {
+        await fetch(
+          `https://cloudidentity.googleapis.com/v1/${resource.id}`,
+          { method: 'DELETE', headers: { Authorization: `Bearer ${googleToken}` } }
+        );
+      },
+      microsoft_app: async () => {
+        await fetch(
+          `https://graph.microsoft.com/v1.0/applications/${resource.id}`,
+          { method: 'DELETE', headers: { Authorization: `Bearer ${microsoftToken}` } }
+        );
+      },
+      microsoft_sp: async () => {
+        await fetch(
+          `https://graph.microsoft.com/v1.0/servicePrincipals/${resource.id}`,
+          { method: 'DELETE', headers: { Authorization: `Bearer ${microsoftToken}` } }
+        );
+      },
+      microsoft_policy: async () => {
+        await fetch(
+          `https://graph.microsoft.com/beta/policies/claimsMappingPolicies/${resource.id}`,
+          { method: 'DELETE', headers: { Authorization: `Bearer ${microsoftToken}` } }
+        );
+      }
+    };
+
+    const handler = deleteHandlers[resource.type];
+    if (handler) {
+      await handler();
+    }
+  }
+
+  getResources() {
+    return [...this.resources];
+  }
+}
+
+export const globalTracker = new TestResourceTracker();

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,7 +2,17 @@ import type { Config } from "jest";
 import nextJest from "next/jest.js";
 
 import { createDefaultEsmPreset, pathsToModuleNameMapper } from "ts-jest";
-import tsConfig from "./tsconfig.json" with { type: "json" };
+import { readFileSync } from "fs";
+
+function readTsConfig() {
+  const text = readFileSync("./tsconfig.json", "utf8");
+  const cleaned = text
+    .replace(/\s*\/\/.*$/gm, "")
+    .replace(/,(?=\s*[}\]])/g, "");
+  return JSON.parse(cleaned);
+}
+
+const tsConfig = readTsConfig();
 
 const createJestConfig = nextJest({ dir: "./" });
 

--- a/jest.globalSetup.ts
+++ b/jest.globalSetup.ts
@@ -1,11 +1,28 @@
+import { globalTracker } from './__tests__/setup/test-resource-tracker';
+
 const globalSetup = async () => {
-  process.env.AUTH_SECRET ??= "test-secret";
-  process.env.GOOGLE_CLIENT_ID ??= "dummy";
-  process.env.GOOGLE_CLIENT_SECRET ??= "dummy";
-  process.env.MICROSOFT_CLIENT_ID ??= "dummy";
-  process.env.MICROSOFT_CLIENT_SECRET ??= "dummy";
-  const { setupTestEnvironment } = await import("./test-utils/testEnv");
+  // Set test environment
+  process.env.NODE_ENV = 'test';
+  process.env.AUTH_SECRET = 'test-secret-key-for-encryption-must-be-32-bytes-long';
+  
+  // Load any existing tracked resources (in case of previous failure)
+  await globalTracker.load();
+  const existingResources = globalTracker.getResources();
+  if (existingResources.length > 0) {
+    console.warn(`[WARNING] Found ${existingResources.length} resources from previous test run`);
+    console.warn('[WARNING] Run jest.globalTeardown to clean them up');
+  }
+  
+  // Get real tokens
+  const { setupTestEnvironment } = await import('./test-utils/testEnv');
   await setupTestEnvironment();
+  
+  // Verify tokens were acquired
+  if (!process.env.GOOGLE_ACCESS_TOKEN || !process.env.MICROSOFT_ACCESS_TOKEN) {
+    throw new Error('Failed to acquire test tokens. Check your credentials.');
+  }
+  
+  console.log('[SETUP] Test environment ready with live API tokens');
 };
 
 export default globalSetup;

--- a/jest.globalTeardown.ts
+++ b/jest.globalTeardown.ts
@@ -1,7 +1,20 @@
-import { teardownTestEnvironment } from "./test-utils/testEnv";
+import { globalTracker } from './__tests__/setup/test-resource-tracker';
 
 const globalTeardown = async () => {
-  await teardownTestEnvironment();
+  console.log('[TEARDOWN] Starting cleanup...');
+  
+  const googleToken = process.env.GOOGLE_ACCESS_TOKEN;
+  const microsoftToken = process.env.MICROSOFT_ACCESS_TOKEN;
+  
+  if (!googleToken || !microsoftToken) {
+    console.error('[TEARDOWN] Missing tokens for cleanup!');
+    return;
+  }
+  
+  // Clean up all tracked resources
+  await globalTracker.cleanup(googleToken, microsoftToken);
+  
+  console.log('[TEARDOWN] Cleanup complete');
 };
 
 export default globalTeardown;


### PR DESCRIPTION
## Summary
- add TestResourceTracker to record and clean up resources created in live API tests
- add helper to create a live API context that tracks new resources
- improve Jest global setup/teardown to use the tracker and require real tokens
- adjust Jest config for JSON parsing
- provide a unit test for the tracker

## Testing
- `pnpm test __tests__/setup/test-resource-tracker.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_684cd1c306a48322baa3e8edfaafd4e1