### PR TITLE
Add live API tests for Google Admin endpoints

### DIFF
--- a/__tests__/endpoints/admin/list-domains.test.ts
+++ b/__tests__/endpoints/admin/list-domains.test.ts
@@ -1,0 +1,44 @@
+import { listDomains } from "@/app/lib/workflow/endpoints/admin/list-domains";
+import { createLiveApiContext } from "../../setup/live-api-context";
+
+describe("listDomains - Live API", () => {
+  let apiContext: ReturnType<typeof createLiveApiContext>;
+
+  beforeAll(() => {
+    const googleToken = process.env.GOOGLE_ACCESS_TOKEN!;
+    const microsoftToken = process.env.MICROSOFT_ACCESS_TOKEN!;
+
+    if (!googleToken) {
+      throw new Error("GOOGLE_ACCESS_TOKEN not set");
+    }
+
+    apiContext = createLiveApiContext({
+      googleToken,
+      microsoftToken,
+      trackCreatedResources: false, // List operations don't create resources
+    });
+  });
+
+  it("should list domains successfully", async () => {
+    const result = await listDomains(apiContext, { customerId: "my_customer" });
+
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("domains");
+    expect(Array.isArray(result.domains)).toBe(true);
+
+    // Should have at least the primary domain
+    expect(result.domains.length).toBeGreaterThan(0);
+
+    const primaryDomain = (
+      result.domains as Array<{ isPrimary?: boolean; verified?: boolean }>
+    ).find((d) => d.isPrimary);
+    expect(primaryDomain).toBeDefined();
+    expect(primaryDomain.verified).toBe(true);
+  });
+
+  it("should handle invalid customer ID", async () => {
+    await expect(
+      listDomains(apiContext, { customerId: "invalid_customer_id" })
+    ).rejects.toThrow();
+  });
+});

--- a/__tests__/endpoints/admin/org-units.test.ts
+++ b/__tests__/endpoints/admin/org-units.test.ts
@@ -1,0 +1,56 @@
+import { getOU, postOU } from "@/app/lib/workflow/endpoints/admin";
+import { createLiveApiContext } from "../../setup/live-api-context";
+
+describe("Org Units - Live API", () => {
+  let apiContext: ReturnType<typeof createLiveApiContext>;
+  const testOuName = `TestOU_${Date.now()}`;
+  const testOuPath = `/${testOuName}`;
+
+  beforeAll(() => {
+    const googleToken = process.env.GOOGLE_ACCESS_TOKEN!;
+    const microsoftToken = process.env.MICROSOFT_ACCESS_TOKEN!;
+
+    apiContext = createLiveApiContext({
+      googleToken,
+      microsoftToken,
+      trackCreatedResources: true,
+    });
+  });
+
+  it("should create and retrieve an org unit", async () => {
+    // Create OU
+    const createResult = await postOU(apiContext, {
+      customerId: "my_customer",
+      body: { name: testOuName, parentOrgUnitPath: "/" },
+    });
+
+    expect(createResult).toHaveProperty("orgUnitId");
+    expect(createResult.name).toBe(testOuName);
+
+    // Verify it exists
+    const getResult = await getOU(apiContext, {
+      customerId: "my_customer",
+      orgUnitPath: testOuPath,
+    });
+
+    expect(getResult.orgUnitPath).toBe(testOuPath);
+  });
+
+  it("should handle duplicate OU creation", async () => {
+    const duplicateName = `DupeOU_${Date.now()}`;
+
+    // Create first
+    await postOU(apiContext, {
+      customerId: "my_customer",
+      body: { name: duplicateName, parentOrgUnitPath: "/" },
+    });
+
+    // Try to create duplicate
+    await expect(
+      postOU(apiContext, {
+        customerId: "my_customer",
+        body: { name: duplicateName, parentOrgUnitPath: "/" },
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/__tests__/endpoints/admin/privileges.test.ts
+++ b/__tests__/endpoints/admin/privileges.test.ts
@@ -1,0 +1,30 @@
+import { listPrivileges } from "@/app/lib/workflow/endpoints/admin";
+import { createLiveApiContext } from "../../setup/live-api-context";
+
+describe("Privileges - Live API", () => {
+  let apiContext: ReturnType<typeof createLiveApiContext>;
+
+  beforeAll(() => {
+    const googleToken = process.env.GOOGLE_ACCESS_TOKEN!;
+    const microsoftToken = process.env.MICROSOFT_ACCESS_TOKEN!;
+
+    apiContext = createLiveApiContext({
+      googleToken,
+      microsoftToken,
+      trackCreatedResources: false,
+    });
+  });
+
+  it("should list privileges", async () => {
+    const res = await listPrivileges(apiContext, { customerId: "my_customer" });
+    expect(res).toBeDefined();
+    expect(Array.isArray(res.items)).toBe(true);
+    expect(res.items.length).toBeGreaterThan(0);
+  });
+
+  it("should handle invalid customer ID", async () => {
+    await expect(
+      listPrivileges(apiContext, { customerId: "bad_customer" })
+    ).rejects.toThrow();
+  });
+});

--- a/__tests__/endpoints/admin/role-assignments.test.ts
+++ b/__tests__/endpoints/admin/role-assignments.test.ts
@@ -1,0 +1,115 @@
+import {
+  getRoleAssign,
+  postRole,
+  postRoleAssign,
+  postUser,
+} from "@/app/lib/workflow/endpoints/admin";
+import { createLiveApiContext } from "../../setup/live-api-context";
+
+describe("Role Assignments - Live API", () => {
+  let apiContext: ReturnType<typeof createLiveApiContext>;
+  let roleId: string;
+  let userId: string;
+  let assignmentId: string;
+  let primaryDomain: string;
+
+  beforeAll(async () => {
+    const googleToken = process.env.GOOGLE_ACCESS_TOKEN!;
+    const microsoftToken = process.env.MICROSOFT_ACCESS_TOKEN!;
+
+    apiContext = createLiveApiContext({
+      googleToken,
+      microsoftToken,
+      trackCreatedResources: true,
+    });
+
+    // create a user
+    const { listDomains } = await import("@/app/lib/workflow/endpoints/admin");
+    const domains = await listDomains(apiContext, {
+      customerId: "my_customer",
+    });
+    primaryDomain = (
+      domains.domains as Array<{ domainName: string; isPrimary?: boolean }>
+    ).find((d) => d.isPrimary)!.domainName;
+
+    const userRes = await postUser(apiContext, {
+      body: {
+        primaryEmail: `assignuser${Date.now()}@${primaryDomain}`,
+        password: `TempPass${Date.now()}!`,
+        name: { givenName: "Assign", familyName: "User" },
+      },
+    });
+    userId = userRes.id;
+
+    // create a role
+    const roleRes = await postRole(apiContext, {
+      customerId: "my_customer",
+      body: {
+        roleName: `AssignRole_${Date.now()}`,
+        rolePrivileges: [
+          { privilegeName: "GROUPS_ALL", serviceId: "00haapch16h1ysv" },
+        ],
+      },
+    });
+    roleId = roleRes.roleId;
+  });
+
+  afterAll(async () => {
+    if (assignmentId) {
+      const googleToken = process.env.GOOGLE_ACCESS_TOKEN!;
+      await fetch(
+        `https://admin.googleapis.com/admin/directory/v1/customer/my_customer/roleassignments/${assignmentId}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${googleToken}` },
+        }
+      ).catch(() => {});
+    }
+  });
+
+  it("should create and retrieve a role assignment", async () => {
+    const assignRes = await postRoleAssign(apiContext, {
+      customerId: "my_customer",
+      body: { roleId, assignedTo: userId, assigneeType: "user" },
+    });
+
+    assignmentId = assignRes.roleAssignmentId;
+    expect(assignRes.roleId).toBe(roleId);
+    expect(assignRes.assignedTo).toBe(userId);
+
+    const listRes = await getRoleAssign(apiContext, {
+      customerId: "my_customer",
+      roleId,
+      assignedTo: userId,
+    });
+
+    expect(Array.isArray(listRes.items)).toBe(true);
+    const found = (listRes.items as Array<{ roleAssignmentId: string }>).find(
+      (i) => i.roleAssignmentId === assignmentId
+    );
+    expect(found).toBeDefined();
+  });
+
+  it("should prevent duplicate assignments", async () => {
+    await postRoleAssign(apiContext, {
+      customerId: "my_customer",
+      body: { roleId, assignedTo: userId, assigneeType: "user" },
+    });
+
+    await expect(
+      postRoleAssign(apiContext, {
+        customerId: "my_customer",
+        body: { roleId, assignedTo: userId, assigneeType: "user" },
+      })
+    ).rejects.toThrow();
+  });
+
+  it("should handle invalid role", async () => {
+    await expect(
+      postRoleAssign(apiContext, {
+        customerId: "my_customer",
+        body: { roleId: "123", assignedTo: userId, assigneeType: "user" },
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/__tests__/endpoints/admin/roles.test.ts
+++ b/__tests__/endpoints/admin/roles.test.ts
@@ -1,0 +1,76 @@
+import { listRoles, postRole } from "@/app/lib/workflow/endpoints/admin";
+import { createLiveApiContext } from "../../setup/live-api-context";
+
+describe("Roles - Live API", () => {
+  let apiContext: ReturnType<typeof createLiveApiContext>;
+  const testRoleName = `TestRole_${Date.now()}`;
+
+  beforeAll(() => {
+    const googleToken = process.env.GOOGLE_ACCESS_TOKEN!;
+    const microsoftToken = process.env.MICROSOFT_ACCESS_TOKEN!;
+
+    apiContext = createLiveApiContext({
+      googleToken,
+      microsoftToken,
+      trackCreatedResources: true,
+    });
+  });
+
+  it("should create and list roles", async () => {
+    const createRes = await postRole(apiContext, {
+      customerId: "my_customer",
+      body: {
+        roleName: testRoleName,
+        rolePrivileges: [
+          { privilegeName: "GROUPS_ALL", serviceId: "00haapch16h1ysv" },
+        ],
+      },
+    });
+
+    expect(createRes.roleId).toBeDefined();
+    expect(createRes.roleName).toBe(testRoleName);
+
+    const listRes = await listRoles(apiContext, { customerId: "my_customer" });
+    const found = (
+      listRes.items as Array<{ roleName?: string }> | undefined
+    )?.find((r) => r.roleName === testRoleName);
+    expect(found).toBeDefined();
+  });
+
+  it("should prevent duplicate role names", async () => {
+    const dupeName = `DupeRole_${Date.now()}`;
+    await postRole(apiContext, {
+      customerId: "my_customer",
+      body: {
+        roleName: dupeName,
+        rolePrivileges: [
+          { privilegeName: "GROUPS_ALL", serviceId: "00haapch16h1ysv" },
+        ],
+      },
+    });
+
+    await expect(
+      postRole(apiContext, {
+        customerId: "my_customer",
+        body: {
+          roleName: dupeName,
+          rolePrivileges: [
+            { privilegeName: "GROUPS_ALL", serviceId: "00haapch16h1ysv" },
+          ],
+        },
+      })
+    ).rejects.toThrow();
+  });
+
+  it("should handle invalid customer ID", async () => {
+    await expect(
+      listRoles(apiContext, { customerId: "bad_customer" })
+    ).rejects.toThrow();
+  });
+
+  it("should validate role body", async () => {
+    await expect(
+      postRole(apiContext, { customerId: "my_customer", body: {} })
+    ).rejects.toThrow();
+  });
+});

--- a/__tests__/endpoints/admin/users.test.ts
+++ b/__tests__/endpoints/admin/users.test.ts
@@ -1,0 +1,67 @@
+import {
+  getUser,
+  postUser,
+  updateUser,
+} from "@/app/lib/workflow/endpoints/admin";
+import { createLiveApiContext } from "../../setup/live-api-context";
+
+describe("Users - Live API", () => {
+  let apiContext: ReturnType<typeof createLiveApiContext>;
+  let primaryDomain: string;
+  const timestamp = Date.now();
+
+  beforeAll(async () => {
+    const googleToken = process.env.GOOGLE_ACCESS_TOKEN!;
+    const microsoftToken = process.env.MICROSOFT_ACCESS_TOKEN!;
+
+    apiContext = createLiveApiContext({
+      googleToken,
+      microsoftToken,
+      trackCreatedResources: true,
+    });
+
+    // Get primary domain first
+    const { listDomains } = await import("@/app/lib/workflow/endpoints/admin");
+    const domains = await listDomains(apiContext, {
+      customerId: "my_customer",
+    });
+    primaryDomain = (
+      domains.domains as Array<{ domainName: string; isPrimary?: boolean }>
+    ).find((d) => d.isPrimary)!.domainName;
+  });
+
+  it("should create, retrieve and update a user", async () => {
+    const testEmail = `testuser${timestamp}@${primaryDomain}`;
+
+    // Create user
+    const createResult = await postUser(apiContext, {
+      body: {
+        primaryEmail: testEmail,
+        password: `TempPass${Date.now()}!`,
+        name: { givenName: "Test", familyName: "User" },
+      },
+    });
+
+    expect(createResult.primaryEmail).toBe(testEmail);
+    expect(createResult.id).toBeDefined();
+
+    // Get user
+    const getResult = await getUser(apiContext, { userEmail: testEmail });
+
+    expect(getResult.primaryEmail).toBe(testEmail);
+
+    // Update user
+    const updateResult = await updateUser(apiContext, {
+      userEmail: testEmail,
+      body: { name: { givenName: "Updated" } },
+    });
+
+    expect(updateResult.name.givenName).toBe("Updated");
+  });
+
+  it("should handle non-existent user", async () => {
+    await expect(
+      getUser(apiContext, { userEmail: "nonexistent@example.com" })
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for listing domains
- add CRUD tests for org units, users, roles, role assignments, and privileges

## Testing
- `pnpm lint` *(fails: unexpected any in existing setup files)*
- `pnpm test` *(fails: GOOGLE_ACCESS_TOKEN not set / network errors)*

------
https://chatgpt.com/codex/tasks/task_e_684cd3d65664832293ce892b1f8d74a0