### PR TITLE
Add Cloud Identity live API tests

### DIFF
--- a/__tests__/endpoints/ci/saml-profiles.test.ts
+++ b/__tests__/endpoints/ci/saml-profiles.test.ts
@@ -1,0 +1,56 @@
+import { listSamlProfiles, createSamlProfile, getIdpCreds } from '@/app/lib/workflow/endpoints/ci';
+import { createLiveApiContext } from '../../setup/live-api-context';
+
+describe('SAML Profiles - Live API', () => {
+  let apiContext: ReturnType<typeof createLiveApiContext>;
+  let testProfileId: string;
+  
+  beforeAll(() => {
+    const googleToken = process.env.GOOGLE_ACCESS_TOKEN!;
+    const microsoftToken = process.env.MICROSOFT_ACCESS_TOKEN!;
+    
+    apiContext = createLiveApiContext({
+      googleToken,
+      microsoftToken,
+      trackCreatedResources: true
+    });
+  });
+
+  it('should create and list SAML profiles', async () => {
+    // Create profile
+    const createResult = await createSamlProfile(apiContext, {
+      body: {
+        displayName: `Test SAML ${Date.now()}`,
+        idpConfig: {
+          entityId: `https://test.example.com/${Date.now()}`,
+          singleSignOnServiceUri: 'https://test.example.com/sso'
+        }
+      }
+    });
+    
+    expect(createResult.done).toBe(true);
+    expect(createResult.response).toBeDefined();
+    testProfileId = createResult.response.name;
+    
+    // List profiles
+    const listResult = await listSamlProfiles(apiContext, {});
+    expect(listResult.inboundSamlSsoProfiles).toBeDefined();
+    
+    const found = listResult.inboundSamlSsoProfiles?.find(
+      (p: any) => p.name === testProfileId
+    );
+    expect(found).toBeDefined();
+  });
+
+  it('should handle missing credentials gracefully', async () => {
+    if (testProfileId) {
+      const profileId = testProfileId.split('/').pop() as string;
+      const result = await getIdpCreds(apiContext, {
+        samlProfileId: profileId
+      });
+      
+      // Might be empty initially
+      expect(result).toBeDefined();
+    }
+  });
+});

--- a/__tests__/endpoints/ci/sso-assignments.test.ts
+++ b/__tests__/endpoints/ci/sso-assignments.test.ts
@@ -1,0 +1,30 @@
+import { listSsoAssignments } from '@/app/lib/workflow/endpoints/ci';
+import { createLiveApiContext } from '../../setup/live-api-context';
+
+describe('SSO Assignments - Live API', () => {
+  let apiContext: ReturnType<typeof createLiveApiContext>;
+  
+  beforeAll(() => {
+    const googleToken = process.env.GOOGLE_ACCESS_TOKEN!;
+    const microsoftToken = process.env.MICROSOFT_ACCESS_TOKEN!;
+    
+    apiContext = createLiveApiContext({
+      googleToken,
+      microsoftToken,
+      trackCreatedResources: true
+    });
+  });
+
+  it('should list SSO assignments', async () => {
+    const result = await listSsoAssignments(apiContext, {});
+    
+    expect(result).toBeDefined();
+    // May or may not have assignments
+    if (result.inboundSsoAssignments) {
+      expect(Array.isArray(result.inboundSsoAssignments)).toBe(true);
+    }
+  });
+
+  // Note: Creating SSO assignments requires a valid SAML profile
+  // This would be tested in integration tests
+});

--- a/__tests__/setup/live-api-context.ts
+++ b/__tests__/setup/live-api-context.ts
@@ -1,0 +1,1 @@
+export { createLiveApiContext } from '../../test-utils/live-api-context';

--- a/app/lib/workflow/constants.ts
+++ b/app/lib/workflow/constants.ts
@@ -263,10 +263,13 @@ export const API_PATHS = {
   USER: "/admin/directory/v1/customer/{customerId}/users/{userId}",
 
   // Google Cloud-Identity
-  IDP_CERTS: "/inboundSamlSsoProfiles/{samlProfileId}:uploadCertificate",
-  SAML_PROFILES: "/inboundSamlSsoProfiles",
-  SAML_PROFILE: "/inboundSamlSsoProfiles/{samlProfileId}",
-  SSO_ASSIGNMENTS: "/inboundSsoAssignments",
+  // Paths include the version prefix because the Cloud Identity base URL is the
+  // host without a trailing `/v1`. Using absolute paths avoids `URL()` stripping
+  // the version segment during resolution.
+  IDP_CERTS: "/v1/inboundSamlSsoProfiles/{samlProfileId}:uploadCertificate",
+  SAML_PROFILES: "/v1/inboundSamlSsoProfiles",
+  SAML_PROFILE: "/v1/inboundSamlSsoProfiles/{samlProfileId}",
+  SSO_ASSIGNMENTS: "/v1/inboundSsoAssignments",
 
   // Microsoft Graph (v1.0 & beta)
   APP_TEMPLATES: "/applicationTemplates",
@@ -297,9 +300,9 @@ export const API_PATHS = {
     "/servicePrincipals/{servicePrincipalId}/samlSingleSignOnSettings",
 
   // Additional Cloud-Identity
-  IDP_CREDENTIALS: "/inboundSamlSsoProfiles/{samlProfileId}/idpCredentials",
+  IDP_CREDENTIALS: "/v1/inboundSamlSsoProfiles/{samlProfileId}/idpCredentials",
   ADD_IDP_CREDENTIALS:
-    "/inboundSamlSsoProfiles/{samlProfileId}/idpCredentials:add",
+    "/v1/inboundSamlSsoProfiles/{samlProfileId}/idpCredentials:add",
 
   // Additional Admin SDK
   USERS_ROOT: "/admin/directory/v1/users",

--- a/test-utils/live-api-context.ts
+++ b/test-utils/live-api-context.ts
@@ -25,7 +25,9 @@ export function createLiveApiContext(options: LiveApiOptions): ApiContext {
       // Build full URL
       const baseUrls: Record<string, string> = {
         googleAdmin: "https://admin.googleapis.com/admin/directory/v1",
-        googleCI: "https://cloudidentity.googleapis.com/v1",
+        // Cloud Identity base host without version so that paths including
+        // `/v1` resolve correctly when passed to `new URL`.
+        googleCI: "https://cloudidentity.googleapis.com",
         graphGA: "https://graph.microsoft.com/v1.0",
         graphBeta: "https://graph.microsoft.com/beta",
         public: "https://login.microsoftonline.com"


### PR DESCRIPTION
## Summary
- add SAML profile live API test
- add SSO assignment live API test
- export live API context for new test folder
- fix Cloud Identity base URL joining and ID parsing

## Testing
- `pnpm lint`
- `pnpm test --runTestsByPath __tests__/endpoints/ci/saml-profiles.test.ts __tests__/endpoints/ci/sso-assignments.test.ts --json --outputFile=/tmp/test.json`


------
https://chatgpt.com/codex/tasks/task_e_684d0e48c4c48322939cf75695c68ed1