### PR TITLE
Add test for invalid OU parent

### DIFF
--- a/__tests__/endpoints/admin/org-units.test.ts
+++ b/__tests__/endpoints/admin/org-units.test.ts
@@ -65,4 +65,15 @@ describe("Org Units - Live API", () => {
       })
     ).rejects.toThrow();
   });
+
+  it("should fail when parent OU does not exist", async () => {
+    const badOuName = `BadParent_${Date.now()}`;
+
+    await expect(
+      postOU(apiContext, {
+        customerId: "my_customer",
+        body: { name: badOuName, parentOrgUnitPath: "/DoesNotExist" }
+      })
+    ).rejects.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- test Google Admin endpoint for invalid OU parent path

## Testing
- `npm test` *(fails: Test Suites: 1 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684f4af8f9a48322b00826ea5cc33c5a